### PR TITLE
Remove declaration of non-existent method in iOS module

### DIFF
--- a/react-native/ios/ThetaClientReactNative.m
+++ b/react-native/ios/ThetaClientReactNative.m
@@ -2,10 +2,6 @@
 
 @interface RCT_EXTERN_MODULE(ThetaClientReactNative, NSObject)
 
-RCT_EXTERN_METHOD(multiply:(float)a withB:(float)b
-                  withResolver:(RCTPromiseResolveBlock)resolve
-                  withRejecter:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(initialize:(NSString)endPoint
                   withConfig:(NSDictionary*)config
                   withTimeout:(NSDictionary*)timeout


### PR DESCRIPTION
This "multiply" method is not implemented in ThetaClientReactNative.swift. It was probably copied from a guide and left by mistake.
Having this declaration with no corresponding definition causes a crash at app start with React Native 0.76 and new architecture: when looking for method signature for selector "multiply:withB:withResolver:withRejecter:" in parseExportedMethods from RCTInteropTurboModule.mm, we get nil which causes a crash right after.