### PR TITLE
[iOS Example] Replace _allowUniversalAccessFromFileURLs with allowUniversalAccessFromFileURLs

### DIFF
--- a/demos/demo-ios/SdkSample/SphereViewer/Viewer360.swift
+++ b/demos/demo-ios/SdkSample/SphereViewer/Viewer360.swift
@@ -20,7 +20,7 @@ class Viewer360: WKWebView, WKNavigationDelegate {
     init(frame: CGRect) {
         let config = WKWebViewConfiguration()
         config.allowsInlineMediaPlayback = true
-        config.setValue(true, forKey: "_allowUniversalAccessFromFileURLs")
+        config.setValue(true, forKey: "allowUniversalAccessFromFileURLs")
         super.init(frame: frame, configuration: config)
         loadViewer()
     }


### PR DESCRIPTION

A crash occurred in the iOS Example app.

Environment
- Xcode 16.2
- iOS 18.2 (physical device)
- macOS 15.0 (24A335)

I believe allowUniversalAccessFromFileURLs can be used on iOS 14 and later, since these versions are supported by this library.

same issue: https://community.theta360.guide/t/howto-theta-client-1-11-1-with-ios-18-using-swift-from-demo-ios/10133
