### PR TITLE
Fix iOS prebuild with Expo SDK 54+ (RCT-Folly / RCT_USE_RN_DEP)

### DIFF
--- a/react-native/theta-client-react-native.podspec
+++ b/react-native/theta-client-react-native.podspec
@@ -21,14 +21,18 @@ Pod::Spec.new do |s|
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+    if ENV['RCT_USE_RN_DEP'] != '1'
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+    end
     s.pod_target_xcconfig    = {
         "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
         "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
+    if ENV['RCT_USE_RN_DEP'] != '1'
+      s.dependency 'RCT-Folly', folly_version
+    end
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"


### PR DESCRIPTION
When running expo prebuild on Expo SDK 54+, pod install fails because theta-client-react-native declares a direct dependency on `RCT-Folly`, which is no longer resolved that way in the new setup.

## Error

```sh
❯ expo prebuild --clean

✔ Cleared android, ios code
✔ Created native directories
✔ Updated package.json | no changes
About Libraries activity - ADDED
Gradle Plugin Portal repository - ADDED
About Libraries Gradle Plugin repository - ADDED
About Libraries Gradle Plugin - APPLIED
About Libraries Gradle Plugin - CONFIGURED
LicensePlist buildPhase in nativeTarget "PixelGuru" - ADDED
Settings.bundle/Root.plist - ADDED
✔ Finished prebuild
⚠️  Something went wrong running `pod install` in the `ios` directory.
Command `pod install` failed.
└─ Cause: Unable to find a specification for `RCT-Folly` depended upon by `theta-client-react-native`

You have either:
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.


pod install --repo-update --ansi exited with non-zero code: 1
✨  Done in 25.63s.
```

## Cause

In Expo SDK 54+, React Native sets `RCT_USE_RN_DEP=1` and supplies Folly (and related New Architecture deps) itself. This podspec always adds `RCT-Folly` and sets `-DRCT_NEW_ARCH_ENABLED=1` when `RCT_NEW_ARCH_ENABLED=1`, which conflicts with that and leads to the “Unable to find a specification for `RCT-Folly`” error.

## Fix

Only add the `RCT-Folly` dependency and the New Architecture compiler flags when `RCT_USE_RN_DEP != '1'`. When `RCT_USE_RN_DEP=1` (Expo SDK 54+), rely on React Native’s Folly and flags. For the case where we do depend on Folly, pin `RCT-Folly` to `folly_version` to avoid version mismatches.

## Testing

Verified `expo prebuild --clean` and `pod install` succeed in an Expo SDK 54 project using the patch.